### PR TITLE
Add support to import docx file for page creation

### DIFF
--- a/app/Actions/ActivityType.php
+++ b/app/Actions/ActivityType.php
@@ -62,6 +62,8 @@ class ActivityType
     const WEBHOOK_CREATE = 'webhook_create';
     const WEBHOOK_UPDATE = 'webhook_update';
     const WEBHOOK_DELETE = 'webhook_delete';
+    const BOOK_PAGES_DELETE = 'book_pages_delete';
+
 
     /**
      * Get all the possible values.

--- a/app/Entities/Repos/BookRepo.php
+++ b/app/Entities/Repos/BookRepo.php
@@ -137,4 +137,17 @@ class BookRepo
 
         $trashCan->autoClearOld();
     }
+
+    /**
+     * Remove a book pages from the system.
+     *
+     * @throws Exception
+     */
+    public function destroyBookPages(Book $book)
+    {
+        $trashCan = new TrashCan();
+        $trashCan->softDestroyPages($book);
+        Activity::add(ActivityType::BOOK_PAGES_DELETE, $book);
+        $trashCan->autoClearOld();
+    }
 }

--- a/app/Entities/Tools/TrashCan.php
+++ b/app/Entities/Tools/TrashCan.php
@@ -384,4 +384,16 @@ class TrashCan
             $imageService->destroy($entity->cover()->first());
         }
     }
+
+    /**
+     * Send a book pages to the recycle bin.
+     *
+     * @throws Exception
+     */
+    public function softDestroyPages(Book $book)
+    {
+        foreach ($book->pages as $page) {
+            $this->softDestroyPage($page, false);
+        }
+    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -156,4 +156,9 @@ abstract class Controller extends BaseController
     {
         return ['image_extension', 'mimes:jpeg,png,gif,webp', 'max:' . (config('app.upload_limit') * 1000)];
     }
+
+    protected function getMimeTypes(): array
+    {
+        return ['mimetypes:application/msword,application/vnd.ms-word.document,application/vnd.ms-word,application/vnd.openxmlformats-officedocument.wordprocessingml.document'];
+    }
 }

--- a/lang/ar/common.php
+++ b/lang/ar/common.php
@@ -104,4 +104,8 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'سياسة الخصوصية',
     'terms_of_service' => 'اتفاقية شروط الخدمة',
+    'select_document' => 'حدد ملف المستند',
+    'select_document_option' => 'الرجاء تحديد خيار المستند',
+    'append_to' => 'إلحاق بصفحات موجودة',
+    'create_new_pages' => 'أنشئ صفحات جديدة',
 ];

--- a/lang/bg/common.php
+++ b/lang/bg/common.php
@@ -104,4 +104,8 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Лични данни',
     'terms_of_service' => 'Общи условия',
+    'select_document' => 'Изберете файл с документ',
+    'select_document_option' => 'Моля, изберете опция за документ',
+    'append_to' => 'Добавяне към съществуващи страници',
+    'create_new_pages' => 'Създайте нови страници',
 ];

--- a/lang/bs/common.php
+++ b/lang/bs/common.php
@@ -104,4 +104,8 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Pravila o privatnosti',
     'terms_of_service' => 'Uslovi korištenja',
+    'select_document' => 'Odaberite datoteku dokumenta',
+    'select_document_option' => 'Molimo odaberite opciju dokumenta',
+    'append_to' => 'Dodati postojećim stranicama',
+    'create_new_pages' => 'Kreirajte nove stranice',
 ];

--- a/lang/ca/common.php
+++ b/lang/ca/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Política de privadesa',
     'terms_of_service' => 'Condicions del servei',
+
+    'select_document' => 'Seleccioneu el fitxer del document',
+    'select_document_option' => "Seleccioneu l'opció de document",
+    'append_to' => 'Afegeix a pàgines existents',
+    'create_new_pages' => 'Crea pàgines noves',
 ];

--- a/lang/cs/common.php
+++ b/lang/cs/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Zásady ochrany osobních údajů',
     'terms_of_service' => 'Podmínky služby',
+
+    'select_document' => 'Vyberte soubor dokumentu',
+    'select_document_option' => 'Vyberte možnost dokumentu',
+    'append_to' => 'Připojit k existujícím stránkám',
+    'create_new_pages' => 'Vytvořte nové stránky',
 ];

--- a/lang/cy/common.php
+++ b/lang/cy/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privacy Policy',
     'terms_of_service' => 'Terms of Service',
+
+    'select_document' => 'Select document file',
+    'select_document_option' => 'Please select document option',
+    'append_to' => 'Append to existing pages',
+    'create_new_pages' => 'Create new pages',
 ];

--- a/lang/da/common.php
+++ b/lang/da/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privatlivspolitik',
     'terms_of_service' => 'Tjenestevilkår',
+
+    'select_document' => 'Vælg dokumentfil',
+    'select_document_option' => 'Vælg venligst dokumentmulighed',
+    'append_to' => 'Tilføj til eksisterende sider',
+    'create_new_pages' => 'Opret nye sider',
 ];

--- a/lang/de/common.php
+++ b/lang/de/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Datenschutzbestimmungen',
     'terms_of_service' => 'Allgemeine Geschäftsbedingungen',
+
+    'select_document' => 'Dokumentdatei auswählen',
+    'select_document_option' => 'Bitte Dokumentoption auswählen',
+    'append_to' => 'An bestehende Seiten anhängen',
+    'create_new_pages' => 'Erstellen Sie neue Seiten',
 ];

--- a/lang/de_informal/common.php
+++ b/lang/de_informal/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Datenschutzerklärung',
     'terms_of_service' => 'Allgemeine Geschäftsbedingungen',
+
+    'select_document' => 'Dokumentdatei auswählen',
+    'select_document_option' => 'Bitte Dokumentoption auswählen',
+    'append_to' => 'An bestehende Seiten anhängen',
+    'create_new_pages' => 'Erstellen Sie neue Seiten',
 ];

--- a/lang/el/common.php
+++ b/lang/el/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Πολιτική Απορρήτου',
     'terms_of_service' => 'Όροι χρήσης',
+
+    'select_document' => 'Επιλέξτε αρχείο εγγράφου',
+    'select_document_option' => 'Επιλέξτε την επιλογή εγγράφου',
+    'append_to' => 'Προσθήκη σε υπάρχουσες σελίδες',
+    'create_new_pages' => 'Δημιουργήστε νέες σελίδες',
 ];

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privacy Policy',
     'terms_of_service' => 'Terms of Service',
+    
+    'select_document' => 'Select document file',
+    'select_document_option' => 'Please select document option',
+    'append_to' => 'Append to existing pages',
+    'create_new_pages' => 'Create new pages',
 ];

--- a/lang/es/common.php
+++ b/lang/es/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Política de privacidad',
     'terms_of_service' => 'Términos de Servicio',
+
+    'select_document' => 'Seleccionar archivo de documento',
+    'select_document_option' => 'Seleccione la opción del documento',
+    'append_to' => 'Agregar a páginas existentes',
+    'create_new_pages' => 'Crear nuevas páginas',
 ];

--- a/lang/es_AR/common.php
+++ b/lang/es_AR/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Política de privacidad',
     'terms_of_service' => 'Términos de Servicio',
+
+    'select_document' => 'Seleccionar archivo de documento',
+    'select_document_option' => 'Seleccione la opción del documento',
+    'append_to' => 'Agregar a páginas existentes',
+    'create_new_pages' => 'Crear nuevas páginas',
 ];

--- a/lang/et/common.php
+++ b/lang/et/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privaatsus',
     'terms_of_service' => 'Kasutustingimused',
+
+    'select_document' => 'Valige dokumendi fail',
+    'select_document_option' => 'Valige dokumendi valik',
+    'append_to' => 'Lisa olemasolevatele lehtedele',
+    'create_new_pages' => 'Looge uusi lehti',
 ];

--- a/lang/eu/common.php
+++ b/lang/eu/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Pribatutasun politika',
     'terms_of_service' => 'Zerbitzu-baldintzak',
+
+    'select_document' => 'Hautatu dokumentu-fitxategia',
+    'select_document_option' => 'Mesedez, hautatu dokumentuaren aukera',
+    'append_to' => 'Erantsi lehendik dauden orrietara',
+    'create_new_pages' => 'Sortu orrialde berriak',
 ];

--- a/lang/fa/common.php
+++ b/lang/fa/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'سیاست حفظ حریم خصوصی',
     'terms_of_service' => 'شرایط خدمات',
+
+    'select_document' => 'فایل سند را انتخاب کنید',
+    'select_document_option' => 'لطفا گزینه سند را انتخاب کنید',
+    'append_to' => 'به صفحات موجود اضافه شود',
+    'create_new_pages' => 'صفحات جدید ایجاد کنید',
 ];

--- a/lang/fr/common.php
+++ b/lang/fr/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Politique de confidentialité',
     'terms_of_service' => 'Conditions d\'utilisation',
+
+    'select_document' => 'Sélectionnez le fichier du document',
+    'select_document_option' => "Veuillez sélectionner l'option de document",
+    'append_to' => 'Ajouter aux pages existantes',
+    'create_new_pages' => 'Créer de nouvelles pages',
 ];

--- a/lang/he/common.php
+++ b/lang/he/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'מדיניות הפרטיות',
     'terms_of_service' => 'תנאי שימוש',
+
+    'select_document' => 'בחר קובץ מסמך',
+    'select_document_option' => 'אנא בחר באפשרות מסמך',
+    'append_to' => 'הוסף לדפים קיימים',
+    'create_new_pages' => 'צור דפים חדשים',
 ];

--- a/lang/hr/common.php
+++ b/lang/hr/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Politika privatnosti',
     'terms_of_service' => 'Uvjeti korištenja',
+
+    'select_document' => 'Odaberite datoteku dokumenta',
+    'select_document_option' => 'Odaberite opciju dokumenta',
+    'append_to' => 'Dodaj na postojeće stranice',
+    'create_new_pages' => 'Napravite nove stranice',
 ];

--- a/lang/hu/common.php
+++ b/lang/hu/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Adatvédelmi irányelvek',
     'terms_of_service' => 'Felhasználási feltételek',
+
+    'select_document' => 'Válassza ki a dokumentumfájlt',
+    'select_document_option' => 'Kérjük, válassza ki a dokumentum opciót',
+    'append_to' => 'Hozzáfűzés a meglévő oldalakhoz',
+    'create_new_pages' => 'Hozzon létre új oldalakat',
 ];

--- a/lang/id/common.php
+++ b/lang/id/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Kebijakan Privasi',
     'terms_of_service' => 'Ketentuan Layanan',
+
+    'select_document' => 'Pilih file dokumen',
+    'select_document_option' => 'Silakan pilih opsi dokumen',
+    'append_to' => 'Tambahkan ke halaman yang ada',
+    'create_new_pages' => 'Buat halaman baru',
 ];

--- a/lang/it/common.php
+++ b/lang/it/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Norme sulla privacy',
     'terms_of_service' => 'Condizioni del Servizio',
+
+    'select_document' => 'Seleziona il file del documento',
+    'select_document_option' => "Si prega di selezionare l'opzione del documento",
+    'append_to' => 'Aggiungi a pagine esistenti',
+    'create_new_pages' => 'Crea nuove pagine',
 ];

--- a/lang/ja/common.php
+++ b/lang/ja/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'プライバシーポリシー',
     'terms_of_service' => '利用規約',
+
+    'select_document' => 'ドキュメントファイルを選択',
+    'select_document_option' => 'ドキュメントオプションを選択してください',
+    'append_to' => '既存のページに追加',
+    'create_new_pages' => '新しいページを作成する',
 ];

--- a/lang/ka/common.php
+++ b/lang/ka/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privacy Policy',
     'terms_of_service' => 'Terms of Service',
+
+    'select_document' => 'Select document file',
+    'select_document_option' => 'Please select document option',
+    'append_to' => 'Append to existing pages',
+    'create_new_pages' => 'Create new pages',
 ];

--- a/lang/ko/common.php
+++ b/lang/ko/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => '개인 정보 처리 방침',
     'terms_of_service' => '서비스 이용 약관',
+
+    'select_document' => '문서 파일 선택',
+    'select_document_option' => '문서 옵션을 선택하세요.',
+    'append_to' => '기존 페이지에 추가',
+    'create_new_pages' => '새 페이지 만들기',
 ];

--- a/lang/lt/common.php
+++ b/lang/lt/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privatumo politika',
     'terms_of_service' => 'Paslaugų teikimo paslaugos',
+
+    'select_document' => 'Pasirinkite dokumento failą',
+    'select_document_option' => 'Pasirinkite dokumento parinktį',
+    'append_to' => 'Pridėti prie esamų puslapių',
+    'create_new_pages' => 'Sukurti naujus puslapius',
 ];

--- a/lang/lv/common.php
+++ b/lang/lv/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privātuma politika',
     'terms_of_service' => 'Pakalpojuma noteikumi',
+
+    'select_document' => 'Izvēlieties dokumenta failu',
+    'select_document_option' => 'Lūdzu, atlasiet dokumenta opciju',
+    'append_to' => 'Pievienot esošajām lapām',
+    'create_new_pages' => 'Izveidojiet jaunas lapas',
 ];

--- a/lang/nb/common.php
+++ b/lang/nb/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Personvernregler',
     'terms_of_service' => 'Bruksvilkår',
+
+    'select_document' => 'Velg dokumentfil',
+    'select_document_option' => 'Velg dokumentalternativ',
+    'append_to' => 'Legg til eksisterende sider',
+    'create_new_pages' => 'Opprett nye sider',
 ];

--- a/lang/nl/common.php
+++ b/lang/nl/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privacybeleid',
     'terms_of_service' => 'Algemene voorwaarden',
+
+    'select_document' => 'Selecteer documentbestand',
+    'select_document_option' => 'Selecteer de documentoptie',
+    'append_to' => "Toevoegen aan bestaande pagina's",
+    'create_new_pages' => "Nieuwe pagina's maken",
 ];

--- a/lang/pl/common.php
+++ b/lang/pl/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Polityka prywatności',
     'terms_of_service' => 'Warunki usługi',
+
+    'select_document' => 'Wybierz plik dokumentu',
+    'select_document_option' => 'Wybierz opcję dokumentu',
+    'append_to' => 'Dołącz do istniejących stron',
+    'create_new_pages' => 'Utwórz nowe strony',
 ];

--- a/lang/pt/common.php
+++ b/lang/pt/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Política de Privacidade',
     'terms_of_service' => 'Termos de Utilização',
+
+    'select_document' => 'Selecione o arquivo do documento',
+    'select_document_option' => 'Selecione a opção de documento',
+    'append_to' => 'Anexar a páginas existentes',
+    'create_new_pages' => 'Criar novas páginas',
 ];

--- a/lang/pt_BR/common.php
+++ b/lang/pt_BR/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Políticas de Privacidade',
     'terms_of_service' => 'Termos de Serviço',
+
+    'select_document' => 'Selecione o arquivo do documento',
+    'select_document_option' => 'Selecione a opção de documento',
+    'append_to' => 'Anexar a páginas existentes',
+    'create_new_pages' => 'Criar novas páginas',
 ];

--- a/lang/ro/common.php
+++ b/lang/ro/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Politică de confidențialitate',
     'terms_of_service' => 'Termeni și condiții',
+
+    'select_document' => 'Selectați fișierul document',
+    'select_document_option' => 'Vă rugăm să selectați opțiunea documentului',
+    'append_to' => 'Adăugați la paginile existente',
+    'create_new_pages' => 'Creați pagini noi',
 ];

--- a/lang/ru/common.php
+++ b/lang/ru/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Политика конфиденциальности',
     'terms_of_service' => 'Условия использования',
+
+    'select_document' => 'Выберите файл документа',
+    'select_document_option' => 'Выберите вариант документа',
+    'append_to' => 'Добавить к существующим страницам',
+    'create_new_pages' => 'Создать новые страницы',
 ];

--- a/lang/sk/common.php
+++ b/lang/sk/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Zásady ochrany osobných údajov',
     'terms_of_service' => 'Podmienky používania',
+
+    'select_document' => 'Vyberte súbor dokumentu',
+    'select_document_option' => 'Vyberte možnosť dokumentu',
+    'append_to' => 'Pripojiť k existujúcim stránkam',
+    'create_new_pages' => 'Vytvorte nové stránky',
 ];

--- a/lang/sl/common.php
+++ b/lang/sl/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Pravilnik o zasebnosti',
     'terms_of_service' => 'Pogoji uporabe',
+
+    'select_document' => 'Izberite datoteko dokumenta',
+    'select_document_option' => 'Izberite možnost dokumenta',
+    'append_to' => 'Dodaj na obstoječe strani',
+    'create_new_pages' => 'Ustvarite nove strani',
 ];

--- a/lang/tr/common.php
+++ b/lang/tr/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Gizlilik Politikası',
     'terms_of_service' => 'Hizmet Şartları',
+
+    'select_document' => 'Belge dosyasını seçin',
+    'select_document_option' => 'Lütfen belge seçeneğini seçin',
+    'append_to' => 'Mevcut sayfalara ekle',
+    'create_new_pages' => 'Yeni sayfalar oluştur',
 ];

--- a/lang/uk/common.php
+++ b/lang/uk/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Політика приватності',
     'terms_of_service' => 'Умови використання',
+
+    'select_document' => 'Виберіть файл документа',
+    'select_document_option' => 'Виберіть варіант документа',
+    'append_to' => 'Додати до існуючих сторінок',
+    'create_new_pages' => 'Створюйте нові сторінки',
 ];

--- a/lang/uz/common.php
+++ b/lang/uz/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Privacy Policy',
     'terms_of_service' => 'Terms of Service',
+
+    'select_document' => 'Hujjat faylini tanlang',
+    'select_document_option' => 'Hujjat variantini tanlang',
+    'append_to' => "Mavjud sahifalarga qo'shing",
+    'create_new_pages' => 'Yangi sahifalar yarating',
 ];

--- a/lang/vi/common.php
+++ b/lang/vi/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => 'Chính Sách Quyền Riêng Tư',
     'terms_of_service' => 'Điều khoản Dịch vụ',
+
+    'select_document' => 'Chọn tệp tài liệu',
+    'select_document_option' => 'Vui lòng chọn tùy chọn tài liệu',
+    'append_to' => 'Nối vào các trang hiện có',
+    'create_new_pages' => 'Tạo trang mới',
 ];

--- a/lang/zh_CN/common.php
+++ b/lang/zh_CN/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => '隐私政策',
     'terms_of_service' => '服务条款',
+
+    'select_document' => '选择文档文件',
+    'select_document_option' => '请选择文档选项',
+    'append_to' => '附加到现有页面',
+    'create_new_pages' => '创建新页面',
 ];

--- a/lang/zh_TW/common.php
+++ b/lang/zh_TW/common.php
@@ -104,4 +104,9 @@ return [
     // Not directly used but available for convenience to users.
     'privacy_policy' => '隱私權政策',
     'terms_of_service' => '服務條款',
+
+    'select_document' => '选择文档文件',
+    'select_document_option' => '请选择文档选项',
+    'append_to' => '附加到现有页面',
+    'create_new_pages' => '创建新页面',
 ];

--- a/public/mammoth/script.js
+++ b/public/mammoth/script.js
@@ -1,0 +1,13 @@
+var fileInput = document.getElementById('fileInput');
+var optionDiv = document.getElementById('docs-option-control');
+fileInput.addEventListener('change', function() {
+    var file = fileInput.files[0];
+    mammoth.convertToHtml({arrayBuffer: file})
+        .then(function(result) {
+            var html = result.value;
+            var hiddenField = document.getElementById("html_input");
+            hiddenField.value = html;
+            optionDiv.style.display = 'block';
+        })
+        .done();
+});

--- a/resources/views/books/parts/form.blade.php
+++ b/resources/views/books/parts/form.blade.php
@@ -26,6 +26,34 @@
     </div>
 </div>
 
+<div class="form-group collapsible" component="collapsible" id="docs-control">
+    <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
+        <label>{{ trans('common.document_file') }}</label>
+    </button>
+    <div refs="collapsible@content" class="collapse-content">
+        <p class="small">{{ trans('common.select_document') }}</p>
+        <input type="file" id="fileInput" name="document_file" accept=".docx">
+        <input type="hidden" id="html_input" name="html_input" value="">
+        @if($errors->has('document_file'))
+         <div class="text-neg text-small">{{ $errors->first('document_file') }}</div>
+        @endif
+        @if(isset($model))
+        <div class="my-s" id="docs-option-control" @if(!$errors->has('document_option')) style="display:none" @endif>
+            <p>{{ trans('common.select_document_option') }}</p>
+            <label for="append-to-existing">
+              <input type="radio" id="append-to-existing" name="document_option" value="append"> {{ trans('common.append_to') }}
+            </label>
+            <label for="create-new">
+                <input type="radio" id="create-new" name="document_option" value="new"> {{ trans('common.create_new_pages') }}
+            </label>
+            @if($errors->has('document_option'))
+             <div class="text-neg text-small">{{ $errors->first('document_option') }}</div>
+           @endif
+        </div>
+        @endif
+    </div>
+</div>
+
 <div class="form-group collapsible" component="collapsible" id="tags-control">
     <button refs="collapsible@trigger" type="button" class="collapse-title text-link" aria-expanded="false">
         <label for="tag-manager">{{ trans('entities.book_tags') }}</label>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -66,6 +66,10 @@
 
     @yield('bottom')
     <script src="{{ versioned_asset('dist/app.js') }}" nonce="{{ $cspNonce }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.5.1/mammoth.browser.min.js" nonce="{{ $cspNonce }}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.5.1/mammoth.browser.js" nonce="{{ $cspNonce }}"></script>
+    <script src="{{ asset('mammoth/script.js') }}" nonce="{{ $cspNonce }}"></script>
+   
     @yield('scripts')
 
     @include('layouts.parts.base-body-end')


### PR DESCRIPTION
Added a feature to import DOCX files for page creation. We will count the number of heading tags (H1) to determine the page titles, and the content within each tag's child elements will become the respective page's content. For example, if there are 7 heading tags, we will create 7 pages for the corresponding book.

When editing a book, if we upload a new DOCX file, we have two options: create new pages or append to the existing ones. If we select 'create new pages', we will delete all the existing pages of the respective book and create new ones. If we choose the second option, we will simply append the new pages to the existing ones.



![image](https://user-images.githubusercontent.com/128118386/229785674-163e9e0d-4b56-4754-9d6c-ad3a8b7136bc.png)




![image](https://user-images.githubusercontent.com/128118386/229785843-3d48c322-cde3-49c3-a1b5-37592995086e.png)

